### PR TITLE
feat: switch apptentive sdk to api instead of implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,5 +25,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.apptentive:apptentive-android:5.7.1'
+    api 'com.apptentive:apptentive-android:5.7.1'
 }


### PR DESCRIPTION
## Summary
- switch apptentive sdk in kit to `api` instead of `implementation`

## Testing Plan
- Check pom.xml file to show compile for apptentive sdk