### PR TITLE
fix:Apptentive SDK to be used via mParticle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,6 @@ allprojects {
 }
 
 dependencies {
-    implementation 'com.apptentive:apptentive-kit-android:6.0.3'
+    api 'com.apptentive:apptentive-kit-android:6.0.3'
     testImplementation 'io.mockk:mockk:1.13.3'
 }


### PR DESCRIPTION
 ## Summary
 - A customer mentioned that they cannot use the Apptentive native SDK anymore with the newest version, after further investigation it seems a PR from an Apptentive Engineer changed the build.gradle setting from "api" to "implementation" which will not expand the Apptentive SDK to be used compared to our other integration kits

 ## Testing Plan
 - [Y] Was this tested locally? If not, explain why.
 - E2E testing

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://mparticle-eng.atlassian.net/browse/PRODRDMP-5655
